### PR TITLE
Hbase-connectors 1.0.0-1.0

### DIFF
--- a/hbase-connectors-assembly/pom.xml
+++ b/hbase-connectors-assembly/pom.xml
@@ -63,7 +63,7 @@
               <finalName>hbase-connectors-${revision}</finalName>
               <skipAssembly>false</skipAssembly>
               <appendAssemblyId>true</appendAssemblyId>
-              <tarLongFileMode>gnu</tarLongFileMode>
+              <tarLongFileMode>posix</tarLongFileMode>
 
               <descriptors>
                 <descriptor>src/main/assembly/hbase-connectors-bin.xml</descriptor>

--- a/pom.xml
+++ b/pom.xml
@@ -116,14 +116,14 @@
     <compileSource>1.8</compileSource>
     <java.min.version>${compileSource}</java.min.version>
     <maven.min.version>3.5.0</maven.min.version>
-    <hbase.version>2.1.0</hbase.version>
+    <hbase.version>2.1.10-2.0-SNAPSHOT</hbase.version>
     <maven.compiler.version>3.6.1</maven.compiler.version>
     <exec.maven.version>1.6.0</exec.maven.version>
     <audience-annotations.version>0.5.0</audience-annotations.version>
     <junit.version>4.12</junit.version>
     <hbase-thirdparty.version>2.1.0</hbase-thirdparty.version>
     <hadoop-two.version>2.7.7</hadoop-two.version>
-    <hadoop-three.version>3.0.3</hadoop-three.version>
+    <hadoop-three.version>3.1.4-1.0-SNAPSHOT</hadoop-three.version>
     <hadoop.version>${hadoop-two.version}</hadoop.version>
     <slf4j.version>1.7.25</slf4j.version>
     <checkstyle.version>8.11</checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
   <developers/>
   <properties>
     <!-- See https://maven.apache.org/maven-ci-friendly.html -->
-    <revision>1.0.0</revision>
+    <revision>1.0.0-1.0-SNAPSHOT</revision>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm</maven.build.timestamp.format>
     <buildDate>${maven.build.timestamp}</buildDate>

--- a/spark/hbase-spark-it/pom.xml
+++ b/spark/hbase-spark-it/pom.xml
@@ -200,7 +200,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hbase.connectors.spark</groupId>
-      <artifactId>hbase-spark</artifactId>
+      <artifactId>hbase-spark-2.3.5</artifactId>
       <version>${revision}</version>
     </dependency>
     <dependency>

--- a/spark/hbase-spark/pom.xml
+++ b/spark/hbase-spark/pom.xml
@@ -27,7 +27,7 @@
     <relativePath>../</relativePath>
   </parent>
   <groupId>org.apache.hbase.connectors.spark</groupId>
-  <artifactId>hbase-spark</artifactId>
+  <artifactId>hbase-spark-2.3.5</artifactId>
   <name>Apache HBase - Spark Connector</name>
   <properties />
   <dependencies>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -41,10 +41,10 @@
     <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
     <hbase-thirdparty.version>2.1.0</hbase-thirdparty.version>
     <jackson.version>2.9.2</jackson.version>
-    <spark.version>2.4.0</spark.version>
+    <spark.version>2.3.5-1.0-SNAPSHOT</spark.version>
     <!-- The following version is in sync with Spark's choice
          Please take caution when this version is modified -->
-    <scala.version>2.11.12</scala.version>
+    <scala.version>2.11.8</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
   </properties>
   <dependencyManagement>

--- a/tdp/README.md
+++ b/tdp/README.md
@@ -1,0 +1,39 @@
+# HBase Connectors - TDP
+
+## Build
+
+```
+mvn clean install \
+  -DskipTests \
+  -Dmaven.javdoc.skip=true \
+  -Dcheckstyle.skip=true \
+  -Dfindbugs.skip=true \
+  -Dspotbugs.skip=true \
+  --batch-mode \
+  -fae
+```
+## Build with specific dependencies
+
+```
+mvn clean install \
+  -Dspark.version=2.3.4-1.0 \
+  -Dscala.version=2.11.8 \
+  -Dscala.binary.version=2.11 \
+  -Dhadoop-three.version=3.1.1-0.0 \
+  -Dhbase.version=2.1.10-1.0 \
+  -DskipTests \
+  -Dmaven.javdoc.skip=true \
+  -Dcheckstyle.skip=true \
+  -Dfindbugs.skip=true \
+  -Dspotbugs.skip=true \
+  --batch-mode \
+  -fae
+```
+
+## Test
+
+```
+mvn clean test \
+  --batch-mode \
+  --fail-never
+```


### PR DESCRIPTION
Relates to https://github.com/TOSIT-IO/TDP/pull/90

Use 1.0.0 release of connectors, same as before 1.0.0, can't work on 1.0.1 due to #2 

Bump 3 TDP dependencies (hadoop, hbase and spark) to their TDP 1.1 versions.

I was not able to build the PR as I did not install spark in my local repo yet. I'd appreciate some help here.